### PR TITLE
fix: issue when module runned by deno or bun

### DIFF
--- a/src/path.ts
+++ b/src/path.ts
@@ -103,7 +103,8 @@ export default class Path {
    * Create a new `Path` object for the caller source file.
    */
   static callerFile(): Path {
-    return Path.fromFileURL(new StackUtils().capture(3)[2].getFileName() ?? '');
+    const fileName = new StackUtils().capture(3)[2].getFileName() ?? '';
+    return fileName.startsWith('file://') ? Path.fromFileURL(fileName) : new Path(fileName);
   }
 
   /**
@@ -199,7 +200,8 @@ export default class Path {
    * Create a new `Path` object for the current source file.
    */
   static currentFile(): Path {
-    return Path.fromFileURL(new StackUtils().capture(2)[1].getFileName() ?? '');
+    const fileName = new StackUtils().capture(2)[1].getFileName() ?? '';
+    return fileName.startsWith('file://') ? Path.fromFileURL(fileName) : new Path(fileName);
   }
 
   /**


### PR DESCRIPTION
For some reason when deno or bun runtime environments are used `new StackUtils().capture(2)[1].getFileName()` construct returns file path as is on the system, not as file url

as it's visible on example below the call will just fail

```bash
$ echo "import Path from 'npm:@mojojs/path'; Path.currentFile();" > path.test.ts

$ deno run --allow-read path.test.ts
error: Uncaught (in promise) TypeError: Invalid URL: '/home/agrechkin/test/path.test.ts'
    at getSerialization (ext:deno_url/00_url.js:98:11)
    at new URL (ext:deno_url/00_url.js:405:27)
    at Object.fileURLToPath (node:url:1152:40)
    at Function.fromFileURL (file:///home/agrechkin/.cache/deno/npm/registry.npmjs.org/@mojojs/path/1.6.0/lib/path.js:186:29)
    at Function.currentFile (file:///home/agrechkin/.cache/deno/npm/registry.npmjs.org/@mojojs/path/1.6.0/lib/path.js:153:21)
    at file:///home/agrechkin/test/path.test.ts:1:43
```

the provided change will make sure `Path.currentFile` and `Path.callerFile` are working properly.